### PR TITLE
tableの微調整

### DIFF
--- a/index.css
+++ b/index.css
@@ -132,7 +132,9 @@ section[id="SKILL"] div[class="Contents"] tr td:nth-of-type(1){
 }
 
 section[id="SKILL"] div[class="Contents"] tr td:nth-of-type(2){
-    width:7em;
+    width:3em;
+    text-align:center;
+    flex:0 1;
 }
 
 section[id="SKILL"] div[class="Contents"] tr td:nth-of-type(3){

--- a/index.css
+++ b/index.css
@@ -127,6 +127,18 @@ section[id="SKILL"] div[class="Contents"] td,li{
     background-repeat:no-repeat;
 }
 
+section[id="SKILL"] div[class="Contents"] tr td:nth-of-type(1){
+    width:1.5em;
+}
+
+section[id="SKILL"] div[class="Contents"] tr td:nth-of-type(2){
+    width:7em;
+}
+
+section[id="SKILL"] div[class="Contents"] tr td:nth-of-type(3){
+    width:6em;
+}
+
 td[id="C++"]{
     width:10%;
     background-image:url(https://skillicons.dev/icons?i=cpp);

--- a/index.css
+++ b/index.css
@@ -209,6 +209,7 @@ td[id="STREAMLIT"]{
 
 div[class="RelatedLinks"]{
     font-size:20px;
+    color:#000;
     background-color:#aaa;
     border:5px #000 dashed;
     box-sizing:border-box;
@@ -246,6 +247,7 @@ div[class="RelatedLinks"]{
 
 .RelatedLinks nav button{
     background-color:rgba(255,255,255,0.7);
+    color:inherit;
     text-align:center;
     font-size:2rem;
     width:20rem;

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KouE10e - My Portfolio</title>
+    <!-- <link rel="stylesheet" href="./reset.css"> -->
     <link rel="stylesheet" href="./index.css">
 </head>
 
@@ -94,7 +95,7 @@
                         <table>
                             <tr><td id="OPENCV"></td><td>OpenCV</td><td>★★★☆☆</td></tr>
                             <tr><td id="UNITY"></td><td>Unity</td><td>★★★☆☆</td></tr>
-                            <tr><td id="GOOGLE_COLAB"></td><td>Google Colab</td><td>★★★☆☆</td></tr>
+                            <tr><td id="GOOGLE_COLAB"></td><td style="font-size:0.76rem">Google Colab</td><td>★★★☆☆</td></tr>
                             <tr><td id="STREAMLIT"></td><td>Streamlit</td><td>★★☆☆☆</td></tr>
                             <tr><td id="GIT"></td><td>Git</td><td>★★★☆☆</td></tr>
                         </table>

--- a/reset.css
+++ b/reset.css
@@ -1,0 +1,49 @@
+/* RESET */
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}


### PR DESCRIPTION
# 内容
* Skill項目の各表の幅を固定&調整
* ボタンの色を明示的に指定
* ブラウザのデフォルト設定をリセットするCSSファイルの追加

# 実装内容
* 表の1行に含まれる3列それぞれの大きさ指定
* 表の一部の文字列の大きさを小さく
* Related Links のボタンの文字列の色を黒色に
  - ブラウザに依存しないように